### PR TITLE
Add GET/local that returns local news articles

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2550,6 +2550,11 @@
       "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
       "optional": true
     },
+    "reverse-geocode": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/reverse-geocode/-/reverse-geocode-1.3.3.tgz",
+      "integrity": "sha512-xfFKCmCjLk/WyEtsyZycZwlRiV02alFIjWv/yoTamolLFtWwAGTfk15BhaLblXvMpf+nwrfalzH+3jxc7g+8gA=="
+    },
     "safe-buffer": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
   "dependencies": {
     "axios": "^0.19.2",
     "aylien-news-api": "^3.0.0",
-    "express": "^4.17.1"
+    "express": "^4.17.1",
+    "reverse-geocode": "^1.3.3"
   },
   "devDependencies": {
     "nodemon": "^2.0.2"

--- a/src/routers/aylienRouter.js
+++ b/src/routers/aylienRouter.js
@@ -3,6 +3,7 @@ const express = require('express');
 const { getArticles } = require('../services/aylienApi/getArticles');
 const { getEntities } = require('../services/aylienApi/getEntities');
 const { getPositiveNews } = require('../services/aylienApi/getPositve');
+const { getLocalNews } = require('../services/aylienApi/getLocal');
 
 const router = new express.Router();
 
@@ -60,6 +61,20 @@ router.get('/positive/:query/:nArticles', async (req, res) => {
             res.status(404).send({ error: 'search brought no results' });
         } else {
             res.status(200).send(positiveArticles);
+        }
+    } catch (err) {
+        res.status(400).send(err);
+    }
+});
+
+router.get('/local', async (req, res) => {
+    try {
+        const articles = await getLocalNews(req.body.lat, req.body.long);
+
+        if (articles.length === 0) {
+            res.status(404).send({ error: 'search brought no results' });
+        } else {
+            res.status(200).send(articles);
         }
     } catch (err) {
         res.status(400).send(err);

--- a/src/services/aylienApi/getLocal.js
+++ b/src/services/aylienApi/getLocal.js
@@ -1,0 +1,76 @@
+const reverse = require('reverse-geocode');
+const AylienNewsApi = require('aylien-news-api');
+const { aylienKey, aylienAppId } = require('../../../config');
+
+const defaultClient = AylienNewsApi.ApiClient.instance;
+
+const app_id = defaultClient.authentications['app_id'];
+app_id.apiKey = aylienAppId;
+
+const app_key = defaultClient.authentications['app_key'];
+app_key.apiKey = aylienKey;
+
+const apiInstance = new AylienNewsApi.DefaultApi();
+
+const getNews = async (opts) => {
+    return await new Promise((resolve, reject) => {
+        apiInstance.listStories(opts, (error, data, response) => {
+            try {
+                if (data.stories.length == 0) {
+                    resolve(-1);
+                }
+                let articles = data.stories.map((story) => {
+                    let obj = {
+                        storyId: story.id,
+                        title: story.title,
+                        author: story.author.name,
+                        body: story.body,
+                        source: {
+                            name: story.source.name,
+                            domain: story.source.domain
+                        },
+                        url: story.links.permalink,
+                        keywords: story.keywords
+                    };
+                    return obj;
+                });
+
+                resolve(articles);
+            } catch (err) {
+                reject(err);
+            }
+        });
+    });
+};
+
+const getLocalNews = async (lat, long) => {
+    const geoData = reverse.lookup(lat, long, 'us');
+    const state = geoData.state;
+    const city = geoData.city;
+
+    let opts = {
+        language: ['en'],
+        sort_by: 'recency',
+        sourceScopesCity: [city],
+        sourceScopesState: [state],
+        sourceLocationsCountry: ['US']
+    };
+
+    let articles = await getNews(opts);
+
+    if (articles !== -1) {
+        return articles;
+    }
+    //if the city search brougnt no results, the widen the scope to the state
+    delete opts.sourceScopesCity;
+    articles = await getNews(opts);
+    if (articles !== -1) {
+        return articles;
+    } else {
+        throw new Error('No city or state news found');
+    }
+};
+
+module.exports = {
+    getLocalNews: getLocalNews
+};


### PR DESCRIPTION
Uses geolocation passed in the request body in the form of latitude and
longitude to find local news articles. If city-specific news articles
are found, those are returned. If no city-related news articles are found, then state-related articles are returned. In the case neither of these
are found, then an error is thrown.